### PR TITLE
Explicitly listing VOLUME

### DIFF
--- a/datastax-studio/Dockerfile
+++ b/datastax-studio/Dockerfile
@@ -16,6 +16,8 @@ RUN sed -i "s/  baseDirectory: null/  baseDirectory: \/var\/lib\/datastax-studio
 
 WORKDIR /
 
+VOLUME [ "/var/lib/datastax-studio" ]
+
 # Expose DataStax Studio Port
 EXPOSE 9091
 


### PR DESCRIPTION
Defining VOLUME per:

https://docs.docker.com/engine/reference/builder/#volume

(makes it easier to launch with Kitematic, Rancher.io, etc..)
